### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,8 +1,8 @@
 class ProductsController < ApplicationController
   extend ActiveHash::Associations::ActiveRecordExtensions
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :product, only: [:edit, :show, :update]
-  before_action :check_user, only: [:edit, :update]
+  before_action :product, only: [:edit, :show, :update, :destroy]
+  before_action :check_user, only: [:edit, :update, :destroy]
   
   def index
     @products = Product.includes(:user).order("created_at DESC")
@@ -35,10 +35,10 @@ class ProductsController < ApplicationController
   def show
   end
 
-  # def destroy
-  #   product = Product.find(params[:id])
-  #   product.destroy
-  # end
+  def destroy
+    @product.destroy
+    redirect_to root_path
+  end
   
   private
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @product.user_id %>
         <%= link_to "商品の編集", edit_product_path(@product.id), class: "product-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", product_path(@product.id), method: :delete, class:"product-destroy" %>
+        <%= link_to "削除する", product_path(@product.id), method: :delete, class:"product-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"product-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
 
   # localhost:3000にアクセスしたときにproductsコントローラーのindexアクションをうごかすための記述を書く。
   root to: 'products#index'
-  resources :products, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :products
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
 
   # localhost:3000にアクセスしたときにproductsコントローラーのindexアクションをうごかすための記述を書く。
   root to: 'products#index'
-  resources :products, only: [:index, :new, :create, :show, :edit, :update]
+  resources :products, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
#What
商品削除機能の実装

#Why
出品された商品を削除できるようにするため

#Gyazo一覧
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
→アカウントが出品者の場合
https://gyazo.com/db091e6015b9a9560501dc25bbe95d77
→アカウントが一般者の場合：削除ボタンが表示されない
https://gyazo.com/ee2ab8ec182627f309c73afdd0fa1219